### PR TITLE
Enable DMA chaining

### DIFF
--- a/src/dacout.cpp
+++ b/src/dacout.cpp
@@ -26,6 +26,9 @@
 
 const DacOutputPioSmConfig* DacOutput::s_currentPioConfig = nullptr;
 const DacOutputPioSmConfig* DacOutput::s_previousPioConfig = nullptr;
+int                DacOutput::s_dmaChainSpinChannelIdx;
+volatile uint32_t* DacOutput::s_dmaChainSpinCtrl;
+dma_channel_config DacOutput::s_dmaChainSpinConfigTemplate;
 DacOutput::DmaChannel DacOutput::s_dmaChannels[kNumBuffers];
 uint32_t DacOutput::s_buffers[kNumBuffers][kNumEntriesPerBuffer];
 uint32_t DacOutput::s_currentBufferIdx = 0;
@@ -37,59 +40,142 @@ uint64_t DacOutput::s_frameStartUs = 0;
 uint64_t DacOutput::s_frameDurationUs = 0;
 
 static const DacOutputPioSmConfig* s_activePioSmConfig = nullptr;
+uint32_t s_chainSpinDmaRead = 0;
+uint32_t s_chainSpinDmaWrite = 0;
 
-static critical_section_t s_dmaCriticalSection = {};
+static bool s_dmaIsRunning = false;
+static uint32_t s_flushKickBufferIdx = 0;
+static uint32_t s_numBuffersToQueueBeforeKick = 1;//DacOutput::kNumBuffers;
 
-static LogChannel DacOutputSynchronisation(false);
+//static critical_section_t s_dmaCriticalSection = {};
+static mutex_t s_dmaMutex;
+
+static LogChannel DacOutputSynchronisation(true);
 
 void DacOutput::Init(const DacOutputPioSmConfig& idleSm)
 {
     s_idlePioSmConfig = &idleSm;
-    critical_section_init(&s_dmaCriticalSection);
+    //critical_section_init(&s_dmaCriticalSection);
+    mutex_init(&s_dmaMutex);
+
+    s_dmaChainSpinChannelIdx = dma_claim_unused_channel(true);
+    s_dmaChainSpinCtrl = &(dma_hw->ch[s_dmaChainSpinChannelIdx].ctrl_trig);
+
+    s_dmaChainSpinConfigTemplate = dma_channel_get_default_config(s_dmaChainSpinChannelIdx);
+
+    // Transfer 32 bits each time
+    channel_config_set_transfer_data_size(&s_dmaChainSpinConfigTemplate, DMA_SIZE_32);
+    // Increment read address
+    channel_config_set_read_increment(&s_dmaChainSpinConfigTemplate, false);
+    // Write to the same address (the PIO SM TX FIFO)
+    channel_config_set_write_increment(&s_dmaChainSpinConfigTemplate, false);
+    // Disable address wrapping
+    channel_config_set_ring(&s_dmaChainSpinConfigTemplate, false, 0);
+    channel_config_set_high_priority(&s_dmaChainSpinConfigTemplate, false);
+    // Chain to the 'chainSpin' channel when complete
+    //channel_config_set_chain_to(&s_dmaChainSpinConfigTemplate, 0);
+    dma_channel_set_irq0_enabled(s_dmaChainSpinChannelIdx, false);
+    // Setup the channel
+    dma_channel_configure(s_dmaChainSpinChannelIdx, &s_dmaChainSpinConfigTemplate,
+                          &s_chainSpinDmaWrite, // Write to here
+                          &s_chainSpinDmaRead, // Read from here
+                          1,
+                          false // don't start yet
+    );
+
+
 
     // Claim and initialise a DMA channels for each buffer
     for (uint32_t i = 0; i < kNumBuffers; ++i)
     {
         s_dmaChannels[i].m_channelIdx = dma_claim_unused_channel(true);
+        s_dmaChannels[i].m_chainSpinChannelIdx = dma_claim_unused_channel(true);
     }
     for (uint32_t i = 0; i < kNumBuffers; ++i)
     {
         s_dmaChannels[i].Init(s_buffers[i], s_dmaChannels[(i+1)%kNumBuffers].m_channelIdx);
     }
+    // Start the final DMA channel's spin-chain running
+    s_chainSpinDmaRead = kNumBuffers-1;
+    dma_channel_start(s_dmaChannels[kNumBuffers-1].m_chainSpinChannelIdx);
+    s_numBuffersToQueueBeforeKick = kNumBuffers;
+
     // Configure the processor to run dmaIrqHandler() when DMA IRQ 0 is asserted
     irq_set_exclusive_handler(DMA_IRQ_0, dmaIrqHandler);
     irq_set_enabled(DMA_IRQ_0, true);
+
+    s_dmaChannels[0].m_complete = false;
 }
 
 void DacOutput::DmaChannel::Init(uint32_t* pBufferBase, int chainToDmaChannelIdx)
 {
+    m_chainToChannelIdx = chainToDmaChannelIdx;
     m_pBufferBase = pBufferBase;
-    m_configWithChain = dma_channel_get_default_config(m_channelIdx);
+    m_config = dma_channel_get_default_config(m_channelIdx);
     m_complete = true;
     m_isFinal = false;
 
+    //
+    // Configure the DMA channel
+    //
+
     // Transfer 32 bits each time
-    channel_config_set_transfer_data_size(&m_configWithChain, DMA_SIZE_32);
+    channel_config_set_transfer_data_size(&m_config, DMA_SIZE_32);
     // Increment read address
-    channel_config_set_read_increment(&m_configWithChain, true);
+    channel_config_set_read_increment(&m_config, true);
     // Write to the same address (the PIO SM TX FIFO)
-    channel_config_set_write_increment(&m_configWithChain, false);
+    channel_config_set_write_increment(&m_config, false);
     // Disable address wrapping
-    channel_config_set_ring(&m_configWithChain, false, 0);
-    // Transfer when PIO SM TX FIFO has space
-    //channel_config_set_dreq(&m_configWithChain, );
-    m_configWithoutChain = m_configWithChain;
-    // Kick off the next channel when complete
-    channel_config_set_chain_to(&m_configWithChain, chainToDmaChannelIdx);
+    channel_config_set_ring(&m_config, false, 0);
+    // Chain to the 'chainSpin' channel when complete
+    channel_config_set_chain_to(&m_config, m_chainSpinChannelIdx);
     dma_channel_set_irq0_enabled(m_channelIdx, true);
 
     // Setup the channel
-    dma_channel_configure(m_channelIdx, &m_configWithoutChain,
+    dma_channel_configure(m_channelIdx, &m_config,
                           nullptr, // Write to PIO TX FIFO
                           pBufferBase, // Read values from appropriate outputBuffer
                           0,
                           false // don't start yet
     );
+
+    //
+    // Configure the ChainSpin DMA channel
+    // Setup the channel to copy whatever is in m_liveChainSpinConfig to the control
+    // register of the global spin-chain channel, and then chain to it.
+    // 
+    dma_channel_config chainConfig = dma_channel_get_default_config(m_chainSpinChannelIdx);
+
+    // Transfer 32 bits each time
+    channel_config_set_transfer_data_size(&chainConfig, DMA_SIZE_32);
+    // Increment read address
+    channel_config_set_read_increment(&chainConfig, false);
+    // Write to the same address (the PIO SM TX FIFO)
+    channel_config_set_write_increment(&chainConfig, false);
+    // Disable address wrapping
+    channel_config_set_ring(&chainConfig, false, 0);
+    // Chain to the 'chainSpin' channel when complete
+    channel_config_set_chain_to(&chainConfig, DacOutput::s_dmaChainSpinChannelIdx);
+    dma_channel_set_irq0_enabled(m_chainSpinChannelIdx, false);
+
+    dma_channel_configure(m_chainSpinChannelIdx, &chainConfig,
+                          DacOutput::s_dmaChainSpinCtrl, // Copy m_liveChainSpinConfig to the ctrl 
+                          &m_liveChainSpinConfig,        // register of the spin channel
+                          1,
+                          false // don't start yet
+    );
+
+    //
+    // Configure the 'Spin' and 'Chain' configs to control whether the chainspin
+    // DMA will spin or chain to the next buffer
+    //
+    m_chainSpinSpinConfig = DacOutput::s_dmaChainSpinConfigTemplate;
+    m_chainSpinChainConfig = DacOutput::s_dmaChainSpinConfigTemplate;
+    // Chain to the 'chainSpin' channel when complete
+    channel_config_set_chain_to(&m_chainSpinSpinConfig, m_chainSpinChannelIdx);
+    // Chain to the next buffer channel when complete
+    channel_config_set_chain_to(&m_chainSpinChainConfig, chainToDmaChannelIdx);
+    m_liveChainSpinConfig = m_chainSpinSpinConfig;
 }
 
 void DacOutput::Flush(bool finalFlushForFrame)
@@ -117,31 +203,42 @@ void DacOutput::Flush(bool finalFlushForFrame)
     dmaChannel.ConfigurePioSm(pioTxFifo, dreq);
     dmaChannel.m_pDacOutputPioSmConfigToSet = nullptr;
 
-    critical_section_enter_blocking(&s_dmaCriticalSection);
+    //critical_section_enter_blocking(&s_dmaCriticalSection);
+    //mutex_enter_blocking(&s_dmaMutex);
         dmaChannel.Enable(s_currentEntryIdx);
-        if(++s_numDmaChannelsQueued == 1)
+        ++s_numDmaChannelsQueued;
+
+        if(s_currentPioConfig == s_previousPioConfig)
         {
-            LOG_INFO(DacOutputSynchronisation, "Flush Kick %d\n", s_currentBufferIdx);
-            configureAndStartDma(*s_currentPioConfig, dmaChannel);
+            // Enable chaining on the previous DMA channel so that if it's still running,
+            // it will chain to this one automatically
+            const uint32_t previousBufferIdx = (s_currentBufferIdx + kNumBuffers - 1) % kNumBuffers;
+            LOG_INFO(DacOutputSynchronisation, "Chain [%d, %d]\n", previousBufferIdx, s_currentBufferIdx);
+            s_dmaChannels[previousBufferIdx].EnableChaining();
+            s_chainSpinDmaRead = s_currentBufferIdx;
         }
         else
         {
-            if(s_currentPioConfig == s_previousPioConfig)
-            {
-                // Enable chaining on the previous DMA channel so that if it's still running,
-                // it will chain to this one automatically
-                LOG_INFO(DacOutputSynchronisation, "Chain [%d, %d]\n", (s_currentBufferIdx + kNumBuffers - 1) % kNumBuffers, s_currentBufferIdx);
-                //s_dmaChannels[(s_currentBufferIdx + kNumBuffers - 1) % kNumBuffers].EnableChaining();
-            }
-            else
-            {
-                // We can't chain it, because it requires a change in PIO SM program
-                dmaChannel.m_pDacOutputPioSmConfigToSet = s_currentPioConfig;
-                s_previousPioConfig = s_currentPioConfig;
-            }
-
+            // We can't chain it, because it requires a change in PIO SM program
+            LOG_INFO(DacOutputSynchronisation, "Flush SetSM %d\n", s_currentBufferIdx);
+            dmaChannel.m_pDacOutputPioSmConfigToSet = s_currentPioConfig;
+            s_previousPioConfig = s_currentPioConfig;
         }
-    critical_section_exit(&s_dmaCriticalSection);
+
+
+        if(!s_dmaIsRunning && (finalFlushForFrame || (s_numDmaChannelsQueued >= s_numBuffersToQueueBeforeKick)))
+        {
+            // Wait for the first kick until all the buffers are filled, to give us our best chance
+            // of not draining all the buffers.
+            const uint32_t kickBufferIdx = (s_currentBufferIdx + kNumBuffers - s_numDmaChannelsQueued) % kNumBuffers;
+            LOG_INFO(DacOutputSynchronisation, "Flush Kick %d\n", kickBufferIdx);
+            configureAndStartDma(s_dmaChannels[kickBufferIdx].m_pDacOutputPioSmConfigToSet, s_dmaChannels[(kickBufferIdx + kNumBuffers - 1) % kNumBuffers]);
+            s_chainSpinDmaRead = kickBufferIdx;
+            s_dmaIsRunning = true;
+            s_numBuffersToQueueBeforeKick = 1;
+        }
+    //mutex_exit(&s_dmaMutex);
+    //critical_section_exit(&s_dmaCriticalSection);
 
     // Move on to the next buffer
     if (++s_currentBufferIdx == kNumBuffers)
@@ -154,7 +251,8 @@ void DacOutput::Flush(bool finalFlushForFrame)
     LOG_INFO(DacOutputSynchronisation, "Wait [%d]\n", s_currentBufferIdx);
     while(!nextDmaChannel.m_complete)
     {
-        tight_loop_contents();
+        checkDmaStatus();
+        //tight_loop_contents();
     }
     LOG_INFO(DacOutputSynchronisation, "Done [%d]\n", s_currentBufferIdx);
 
@@ -169,6 +267,7 @@ void DacOutput::Flush(bool finalFlushForFrame)
         // So let's make sure that we always assert the correct PIO SM program
         // for the first flush of the next frame
         s_previousPioConfig = nullptr;
+        s_numBuffersToQueueBeforeKick = 1;//kNumBuffers;
     }
 
 }
@@ -195,12 +294,51 @@ void DacOutput::wait()
     LOG_INFO(DacOutputSynchronisation, "]\n");
 }
 
+//static uint32_t s_int0Bits = 0;
+
 void DacOutput::dmaIrqHandler()
 {
-    critical_section_enter_blocking(&s_dmaCriticalSection);
+    uint32_t int0Bits = dma_hw->ints0;
+    hw_set_bits(&dma_hw->ints0, int0Bits);
+#if 0
+    mutex_enter_blocking(&s_dmaMutex);
+    s_int0Bits |= int0Bits;
+    mutex_exit(&s_dmaMutex);
+    //dma_hw->ints0 = int0Bits;
+    //DmaChannel& dmaChannel = s_dmaChannels[s_nextBufferIrq];
+    //dma_channel_acknowledge_irq0(dmaChannel.m_channelIdx);
+    //dma_hw->ints0 = (1u << dmaChannel.m_channelIdx);
+#endif    
+}
+
+void DacOutput::checkDmaStatus()
+{
+    if(!s_dmaIsRunning)
+    {
+        return;
+    }
     DmaChannel& dmaChannel = s_dmaChannels[s_nextBufferIrq];
+    //dma_channel_acknowledge_irq0(dmaChannel.m_channelIdx);
+    //dma_hw->ints0 = (1u << dmaChannel.m_channelIdx);
+    //uint32_t channelBit = (1u << dmaChannel.m_channelIdx);
+    if(dma_hw->ch[dmaChannel.m_channelIdx].transfer_count > 0)
+    //if(dma_channel_is_busy(dmaChannel.m_channelIdx))
+    //if((s_int0Bits & channelBit) == 0)
+    {
+        LOG_INFO(DacOutputSynchronisation, "DMA busy\n", s_nextBufferIrq);
+        return;
+    }
+    //mutex_enter_blocking(&s_dmaMutex);
+    //s_int0Bits &= ~channelBit;
+    //mutex_exit(&s_dmaMutex);
+    //dma_channel_acknowledge_irq0(dmaChannel.m_channelIdx);
+    //dma_hw->ints0 = channelBit;
+
+    //critical_section_enter_blocking(&s_dmaCriticalSection);
+    //mutex_enter_blocking(&s_dmaMutex);
     LOG_INFO(DacOutputSynchronisation, "IRQ %d %d\n", s_nextBufferIrq, dma_channel_get_irq0_status(dmaChannel.m_channelIdx) ? 1 : 0);
     bool makeIdle = false;
+    assert(!dmaChannel.m_complete);
     if(dmaChannel.m_isFinal)
     {
         dmaChannel.m_isFinal = false;
@@ -210,7 +348,6 @@ void DacOutput::dmaIrqHandler()
     }
 
     s_nextBufferIrq = (s_nextBufferIrq + 1) % kNumBuffers;
-    dma_channel_acknowledge_irq0(dmaChannel.m_channelIdx);
 
     if((--s_numDmaChannelsQueued > 0))
     {
@@ -221,23 +358,45 @@ void DacOutput::dmaIrqHandler()
         // We need to configure the PIO, and kick off
         // this DMA channel right here.
         
-        //if(nextDmaChannel.m_pDacOutputPioSmConfigToSet != nullptr)
+        if(nextDmaChannel.m_pDacOutputPioSmConfigToSet != nullptr)
         {
             LOG_INFO(DacOutputSynchronisation, "IRQ Kick %d\n", s_nextBufferIrq);
-            configureAndStartDma(nextDmaChannel.m_pDacOutputPioSmConfigToSet ? *nextDmaChannel.m_pDacOutputPioSmConfigToSet : *s_activePioSmConfig, nextDmaChannel);
+            configureAndStartDma(nextDmaChannel.m_pDacOutputPioSmConfigToSet, dmaChannel);
             makeIdle = false;
         }
+        else
+        {
+            LOG_INFO(DacOutputSynchronisation, "IRQ Chained %d\n", s_nextBufferIrq);
+            assert(dmaChannel.IsChainingEnabled());
+        }
+    }
+    else
+    {
+        // DMA has been drained, so will be left spinning
+        LOG_INFO(DacOutputSynchronisation, "IRQ Drained\n");
+        s_dmaIsRunning = false;
+        s_flushKickBufferIdx = s_nextBufferIrq;
     }
 
     if(makeIdle)
     {
         // Activate the idle SM
+        LOG_INFO(DacOutputSynchronisation, "Setting idle\n");
         setActivePioSm(*s_idlePioSmConfig);
+        s_numBuffersToQueueBeforeKick = kNumBuffers;
     }
     
     dmaChannel.m_complete = true;
-    critical_section_exit(&s_dmaCriticalSection);
+    LOG_INFO(DacOutputSynchronisation, "IRQ End\n");
+    //mutex_exit(&s_dmaMutex);
+    //critical_section_exit(&s_dmaCriticalSection);
 }
+
+void DacOutput::Poll()
+{
+    checkDmaStatus();
+}
+
 
 void DacOutput::setActivePioSm(const DacOutputPioSmConfig& config)
 {
@@ -262,14 +421,17 @@ void DacOutput::setActivePioSm(const DacOutputPioSmConfig& config)
     }
 }
 
-void DacOutput::configureAndStartDma(const DacOutputPioSmConfig& pioConfig, DmaChannel& dmaChannel)
+void DacOutput::configureAndStartDma(const DacOutputPioSmConfig* pioConfig, DmaChannel& previousDmaChannel)
 {
     if(s_frameStartUs == 0)
     {
         s_frameStartUs = time_us_64();
     }
-    setActivePioSm(pioConfig);
-    dmaChannel.Start();
+    if(pioConfig != nullptr)
+    {
+        setActivePioSm(*pioConfig);
+    }
+    previousDmaChannel.EnableChaining();
 }
 
 void DacOutput::SetCurrentPioSm(const DacOutputPioSmConfig& config)

--- a/src/dacout.h
+++ b/src/dacout.h
@@ -100,83 +100,54 @@ public:
     // For stats.  How much time was spent with active DMA.
     static uint64_t GetFrameDurationUs() {return s_frameDurationUs;}
 
+    // After the frame's final Flush, this should be called frequently
+    // to enable the remaining pending buffers to be sent to the DACs
     static void Poll();
 
 private:
     constexpr static uint32_t kNumBuffers = 3;
     constexpr static uint32_t kNumEntriesPerBuffer = 4096;
 
-    // We have one DMA channel per buffer.
-    // *** Chaining is currently disabled and work-in-progress ***
-    // *** Instead, DMA channels are manually chained within   ***
-    // *** the interrupt handler                               ***
+    // We have one DmaChannel per buffer, but each one uses two actual
+    // DMA channels in order to allow chaining.
+    // And there's one additional global DMA channel too used in the DMA chain spinning.
     struct DmaChannel
     {
         int m_channelIdx;
         int m_chainSpinChannelIdx;
-        int m_chainToChannelIdx;
         uint32_t* m_pBufferBase;
-        io_wo_32* m_pWriteAddress;
         const DacOutputPioSmConfig* m_pDacOutputPioSmConfigToSet;
         dma_channel_config m_config;
         // This config will be poked to the DacOutput::s_dmaChainSpinChannelIdx
         dma_channel_config m_liveChainSpinConfig;
-        // If the value is this config, then we'll keep spinning
+        // If the live one is this config, then we'll keep spinning
         dma_channel_config m_chainSpinSpinConfig;
-        // If the value is this config, then we'll chain to the next buffer
-        dma_channel_config m_chainSpinChainConfig;
+        // If the live one is this config, then we'll chain to the actual buffer DMA
+        dma_channel_config m_chainSpinEnableConfig;
         volatile bool m_complete;
         bool m_isFinal;
 
-        void Init(uint32_t* pBufferBase, int chainToDmaChannelIdx);
-        void Enable(uint32_t numEntries)
+        void Init(uint32_t* pBufferBase, const DmaChannel& chainTo);
+        void Configure(uint32_t numEntries, const DacOutputPioSmConfig& pioConfig);
+
+        void Enable()
         {
-            dma_channel_set_read_addr(m_channelIdx, m_pBufferBase, false);
-            dma_channel_set_write_addr(m_channelIdx, m_pWriteAddress, false);
-            DisableChaining();
-            dma_channel_set_trans_count(m_channelIdx, numEntries, false);
+            m_liveChainSpinConfig = m_chainSpinEnableConfig;
         }
         void Disable()
         {
-            dma_channel_set_trans_count(m_channelIdx, 0, false);
-            dma_channel_set_read_addr(m_channelIdx, m_pBufferBase, false);
-            m_complete = false;
-            m_pDacOutputPioSmConfigToSet = nullptr;
-            DisableChaining();
-        }
-        bool IsBusy() const { return dma_channel_is_busy(m_channelIdx); }
-        void Wait()
-        {
-            dma_channel_wait_for_finish_blocking(m_channelIdx);
-        }
-        void EnableChaining()
-        {
-            m_liveChainSpinConfig = m_chainSpinChainConfig;
-        }
-        void DisableChaining()
-        {
             m_liveChainSpinConfig = m_chainSpinSpinConfig;
         }
-        bool IsChainingEnabled() const
+        bool IsEnabled() const
         {
-            return m_liveChainSpinConfig.ctrl == m_chainSpinChainConfig.ctrl;
-        }
-        void ConfigurePioSm(io_wo_32* pioTxFifo, uint32_t dreq)
-        {
-            m_pWriteAddress = pioTxFifo;
-            channel_config_set_dreq(&m_config, dreq);
-            dma_channel_set_config(m_channelIdx, &m_config, false);
+            return m_liveChainSpinConfig.ctrl == m_chainSpinEnableConfig.ctrl;
         }
     };
     friend struct DmaChannel;
 
-public:
-    static void wait();
 private:
-    static bool isDmaRunning();
-    static void dmaIrqHandler();
     static void setActivePioSm(const DacOutputPioSmConfig& config);
-    static void configureAndStartDma(const DacOutputPioSmConfig* pioConfig, DmaChannel& previousDmaChannel);
+    static void configurePioAndStartDma(DmaChannel& previousDmaChannel);
     static void checkDmaStatus();
 
 private:

--- a/src/displaylist.cpp
+++ b/src/displaylist.cpp
@@ -113,8 +113,8 @@ void DisplayList::PushVector(DisplayListScalar x, DisplayListScalar y, Intensity
     uint32_t numSteps = (time * SPEED_CONSTANT).getIntegerPart() + 1;
     vector.numSteps   = (numSteps > 0xffff) ? 0xffff : (uint16_t)numSteps;
 #if STEP_DIV_IN_DISPLAY_LIST
-    vector.stepX = DisplayListIntermediate(dx) / vector.numSteps;
-    vector.stepY = DisplayListIntermediate(dy) / vector.numSteps;
+    vector.stepX = DisplayListIntermediate(dx) / (int) vector.numSteps;
+    vector.stepY = DisplayListIntermediate(dy) / (int) vector.numSteps;
 #endif
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,8 +138,12 @@ void dacOutputLoop()
     uint64_t        frameDuration = frameEnd - frameStart;
     if (frameDuration < s_numMicrosBetweenFrames)
     {
-        sleep_us(s_numMicrosBetweenFrames - frameDuration);
         /*next*/ frameStart += s_numMicrosBetweenFrames;
+        while(time_us_64() < frameStart)
+        {
+            DacOutput::Poll();
+            sleep_us(50);
+        }
     }
     else
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -151,7 +151,11 @@ void dacOutputLoop()
     // Lock the mutex for the next frame's DisplayList
     uint32_t nextDisplayListIdx = 1 - s_outputDisplayListIdx;
     LOG_INFO(FrameSynchronisation, "DO W: %d\n", nextDisplayListIdx);
-    mutex_enter_blocking(s_displayListMutex + nextDisplayListIdx);
+    //mutex_enter_blocking(s_displayListMutex + nextDisplayListIdx);
+    while(!mutex_try_enter(s_displayListMutex + nextDisplayListIdx, nullptr))
+    {
+        DacOutput::Poll();
+    }
     // Only then do we release this frame's DisplayList
     mutex_exit(s_displayListMutex + s_outputDisplayListIdx);
     s_outputDisplayListIdx = nextDisplayListIdx;


### PR DESCRIPTION
Instead of kicking off the DMA of new buffers using an IRQ, this version chains buffers that use the same PIO SM program.  So the transition between buffers seamless (so no more bright speckles between buffers).